### PR TITLE
JAR files handling, working without locate command etc.

### DIFF
--- a/log4j_checker_beta.sh
+++ b/log4j_checker_beta.sh
@@ -24,8 +24,20 @@ function locate_log4j() {
       /var /etc /usr /opt /lib* \
       -name "*log4j*" \
       2>&1 \
-      | grep -v '^find:.* Permission denied$'
+      | grep -v '^find:.* Permission denied$' \
+      | grep -v '^find:.* No such file or directory$'
   fi
+}
+
+function find_jar_files() {
+  find \
+    /var /etc /usr /opt /lib* \
+    -name "*.jar" \
+    -o -name "*.war" \
+    -o -name "*.ear" \
+    2>&1 \
+    | grep -v '^find:.* Permission denied$' \
+    | grep -v '^find:.* No such file or directory$'
 }
 
 information "Looking for files containing log4j..."
@@ -68,6 +80,19 @@ then
     "so there still could be log4j in such applications."
 else
   information "Java is not installed"
+fi
+
+if [ "$(command -v unzip)" ]
+then
+  information "Analyzing JAR/WAR/EAR files..."
+  find_jar_files | while read -r jar_file
+  do
+    unzip -l "$jar_file" 2> /dev/null \
+      | grep -q -i "log4j" \
+      && warning "$jar_file contains log4j files"
+  done
+else
+  information "Cannot look for log4j inside JAR/WAR/EAR files (unzip not found)"
 fi
 
 cat <<'TEXTEND'

--- a/log4j_checker_beta.sh
+++ b/log4j_checker_beta.sh
@@ -41,7 +41,7 @@ function find_jar_files() {
 }
 
 information "Looking for files containing log4j..."
-OUTPUT="$(locate_log4j | grep -v log4js)"
+OUTPUT="$(locate_log4j | grep -v log4j_checker_beta)"
 if [ "$OUTPUT" ]
 then
   warning "Maybe vulnerable, those files contain the name:"

--- a/log4j_checker_beta.sh
+++ b/log4j_checker_beta.sh
@@ -21,7 +21,7 @@ function locate_log4j() {
     locate log4j
   else
     find \
-      /var /etc /usr /lib* \
+      /var /etc /usr /opt /lib* \
       -name "*log4j*" \
       2>&1 \
       | grep -v '^find:.* Permission denied$'


### PR DESCRIPTION
Hi !

I’ll start to say sorry as my fork goes far apart from your code.

It includes :

- an alternative for when locate is not available (Debian distros for example)
- code for looking inside JAR/WAR/EAR files if they contain *log4j* files
- removal of colors (better for automatisation, better support for dark/light mode in terminal etc.)
- making some tests case insensitive (grep -i)
- formating code in 80 columns
- generalised use of printf instead of echo
- resetting LANG to be sure messages are outputed in english

So don’t be sorry to reject this pull request ;-)