### PR TITLE
Add ability to scan for hashes of vulnerable .class files

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,17 @@ It does not give a 100% proof, that you are not vulnerable, but it gives a hint 
 - checks for packages containing log4j and Solr ElasticSearch
 - checks if Java is installed
 - Analyzes JAR/WAR/EAR files
+- Option of checking hashes of .class files in archives
 
 ## Run with:
 
     wget https://raw.githubusercontent.com/rubo77/log4j_checker_beta/main/log4j_checker_beta.sh -q -O - |bash
+
+## Hash checking
+
+The script can test .class files on the first level of JAR/WAR/EAR archives to see if they match with known sha256 hashes of vulnerable class files from log4j.
+You have to provide a download of plain text file with sha256 hashes in HEX format, one per line, everything after first <space> is ignored.
+The URL can be placed in variable download_file. Otherwise this feature will not operate.
 
 ## dependencies
 

--- a/log4j_checker_beta.sh
+++ b/log4j_checker_beta.sh
@@ -104,11 +104,12 @@ if [ "$(command -v unzip)" ]; then
       && warning "$jar_file contains log4j files"
     if [[ -f "./vulnerable.hashes" ]]; then
       dir_unzip=$(mktemp -d)
+      base_name=$(basename "$jar_file")
       unzip -qq -DD "$jar_file" '*.class' -d "$dir_unzip" \
         && find "$dir_unzip" -type f -not -name "*"$'\n'"*" -name '*.class' -exec sha256sum "{}" \; \
-        | cut -d" " -f1 | sort | uniq > "$dir_unzip/$jar_file.hashes";
-      num_found = $(comm -12 ./vulnerable.hashes "$dir_unzip/$jar_file.hashes" | wc -l)
-      if [[ "$num_found" -gt 0 ]]; then
+        | cut -d" " -f1 | sort | uniq > "$dir_unzip/$base_name.hashes";
+      num_found=$(comm -12 ./vulnerable.hashes "$dir_unzip/$base_name.hashes" | wc -l)
+      if [ $num_found -gt 0 ]; then
         warning "$jar_file contains vulnerable binary classes"
       fi
       rm -rf -- "$dir_unzip"


### PR DESCRIPTION
See my answer on https://serverfault.com/a/1086290/188737

This is a bit roughshod, did a minimal test with a couple of jar files. File vulnerable.hashes with sha256 hashes in hex format, ordered, one per line has to be provided.