### PR TITLE
Interpret result of find_jar_files as a multiline string. 

### DIFF
--- a/log4j_checker_beta.sh
+++ b/log4j_checker_beta.sh
@@ -167,7 +167,7 @@ if [ "$(command -v unzip)" ]; then
       # delete temp folder containing the extracted java files
       rm -rf -- "$dir_unzip"
     fi
-  done <<<$(find_jar_files)
+  done <<<"$(find_jar_files)"
   echo
   if [[ $COUNT -gt 0 ]]; then
     information "Found $COUNT files in unpacked binaries containing the string 'log4j' with $COUNT_FOUND vulnerabilities"


### PR DESCRIPTION
This PR is adding double quotes around the result of 
```
$(find_jar_files)
```

Without the quotes the result of `find_jar_files` is interpreted as a very long space separated one-line string. 
To my understanding without the quotes the loop is not really working as a loop anymore. 
It will only execute one iteration and read all values in one step into the `jar_file` variable.

In most of the cases this is maybe not a problem, but if you have a lot of findings you can you end up in the error 
```
./log4j_checker_beta.sh: line 149: /usr/bin/basename: Argument list too long
```
This is due to a kernel limitation on the size of the command line argument. 
Especially on older systems this can be a problem. For example on my system I have Ubuntu 16.04 with a limit of 

```
$ getconf ARG_MAX
2097152
```

( For more info you can also check : https://stackoverflow.com/a/18647755 )

P.S. I think this fix is related to issue 
 - https://github.com/rubo77/log4j_checker_beta/issues/19